### PR TITLE
[BPK-964] Upgrade eslint versions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/) 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## 3.0.0 - Upgraded `esling-config-airbnb peer dependencies`
+### Changed
+- Upgraded the following peer dependencies:
+ - babel-eslint:           `^7.2.3` -> `^8.0.1`
+ - eslint:                 `^3.17.1` -> `^4.9.0`
+ - eslint-config-airbnb:   `^14.1.0` -> `^16.1.0`
+ - eslint-plugin-import:   `^2.2.0`  -> `^2.8.0`
+ - eslint-plugin-jsx-a11y: `^4.0.0`  -> `^6.0.2`
+ - eslint-plugin-react:    `^6.10.0` -> `^7.4.0`
 
 ## 2.0.0 - Changed parser to `babel-eslint`
 ## Changed

--- a/changelog.md
+++ b/changelog.md
@@ -6,14 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 3.0.0 - Upgraded `esling-config-airbnb peer dependencies`
+
 ### Changed
 - Upgraded the following peer dependencies:
  - babel-eslint:           `^7.2.3` -> `^8.0.1`
- - eslint:                 `^3.17.1` -> `^4.9.0`
- - eslint-config-airbnb:   `^14.1.0` -> `^16.1.0`
- - eslint-plugin-import:   `^2.2.0`  -> `^2.8.0`
- - eslint-plugin-jsx-a11y: `^4.0.0`  -> `^6.0.2`
- - eslint-plugin-react:    `^6.10.0` -> `^7.4.0`
+ - [eslint](https://github.com/eslint/eslint/blob/master/CHANGELOG.md): `^3.17.1` -> `^4.9.0`
+ - [eslint-config-airbnb](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/CHANGELOG.md): `^14.1.0` -> `^16.1.0`
+ - [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import/blob/master/CHANGELOG.md): `^2.2.0`  -> `^2.8.0`
+ - [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md): `^4.0.0`  -> `^6.0.2`
+ - [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md): `^6.10.0` -> `^7.4.0`
 
 ## 2.0.0 - Changed parser to `babel-eslint`
 ## Changed

--- a/index.js
+++ b/index.js
@@ -17,28 +17,21 @@ module.exports = {
   rules: {
     'valid-jsdoc': ['error'],
 
-    // We've decided we don't want this for now as it makes writing JSX more painful.
+    // Disabled whilst incompatibilities still exist with react/jsx-closing-tag-location, react/jsx-indent & max-len.
     // See https://github.com/airbnb/javascript/issues/1584#issuecomment-335667272
     "function-paren-newline": 0,
 
-    // False positive on custom propTypes + isRequired. https://github.com/yannickcr/eslint-plugin-react/issues/1389
+    // Disabled whilst false positives still exist with custom propTypes + isRequired.
+    // See https://github.com/yannickcr/eslint-plugin-react/issues/1389
     "react/no-typos": 0,
 
+    // Added 'to' as a specialLink property, which prevents react-router's
+    // 'Link' component from triggering this rule.
     // See https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/339
     "jsx-a11y/anchor-is-valid": ["error", {
       "components": ["Link"],
       "specialLink": ["to"],
       "aspects": ["noHref", "invalidHref", "preferButton"],
-    }],
-
-    // See https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/282
-    // We should probably change our code to adhere to the standard here.
-    "jsx-a11y/label-has-for": [ 2, {
-      "components": [ "Label" ],
-      "required": {
-          "some": [ "nesting", "id" ]
-      },
-      "allowChildren": false
     }]
   }
 };

--- a/index.js
+++ b/index.js
@@ -15,6 +15,30 @@ module.exports = {
   parser: 'babel-eslint',
   extends: 'airbnb',
   rules: {
-    'valid-jsdoc': ['error']
+    'valid-jsdoc': ['error'],
+
+    // We've decided we don't want this for now as it makes writing JSX more painful.
+    // See https://github.com/airbnb/javascript/issues/1584#issuecomment-335667272
+    "function-paren-newline": 0,
+
+    // False positive on custom propTypes + isRequired. https://github.com/yannickcr/eslint-plugin-react/issues/1389
+    "react/no-typos": 0,
+
+    // See https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/339
+    "jsx-a11y/anchor-is-valid": ["error", {
+      "components": ["Link"],
+      "specialLink": ["to"],
+      "aspects": ["noHref", "invalidHref", "preferButton"],
+    }],
+
+    // See https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/282
+    // We should probably change our code to adhere to the standard here.
+    "jsx-a11y/label-has-for": [ 2, {
+      "components": [ "Label" ],
+      "required": {
+          "some": [ "nesting", "id" ]
+      },
+      "allowChildren": false
+    }]
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint-config-skyscanner",
+  "version": "3.0.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-skyscanner",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Skyscanner's ESLint config.",
   "main": "index.js",
   "repository": {
@@ -18,15 +18,12 @@
     "styleguide"
   ],
   "peerDependencies": {
-    "babel-eslint": "^7.2.3",
-    "eslint": "^3.17.1",
-    "eslint-config-airbnb": "^14.1.0",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-react": "^6.10.0"
-  },
-  "devDependencies": {
-    "np": "^2.10.0"
+    "babel-eslint": "^8.0.1",
+    "eslint": "^4.9.0",
+    "eslint-config-airbnb": "^16.1.0",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-react": "^7.4.0"
   },
   "scripts": {
     "publish": "np",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-skyscanner",
-  "version": "3.0.0",
+  "version": "2.0.0",
   "description": "Skyscanner's ESLint config.",
   "main": "index.js",
   "repository": {

--- a/test/pass.jsx
+++ b/test/pass.jsx
@@ -1,27 +1,11 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
-class Banner extends Component {
-  /**
-   * Represents a book.
-   * @constructor
-   * @param {string} title - The title of the book.
-   * @param {string} author - The author of the book.
-   */
-  constructor() {
-    super();
-
-    this.state = {};
-  }
-
-  render() {
-    return (
-      <div role="banner">
-        { this.props.children }
-      </div>
-    );
-  }
-}
+const Banner = props => (
+  <div role="banner">
+    { props.children }
+  </div>
+);
 
 Banner.propTypes = {
   children: PropTypes.node.isRequired,

--- a/test/pass.jsx
+++ b/test/pass.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 class Banner extends Component {
-    /**
+  /**
    * Represents a book.
    * @constructor
    * @param {string} title - The title of the book.
@@ -11,9 +11,7 @@ class Banner extends Component {
   constructor() {
     super();
 
-    this.state = {
-      key: 'value',
-    };
+    this.state = {};
   }
 
   render() {


### PR DESCRIPTION
Things to discuss:

- Should this be a major release as it's likely to contain 'breaking' changes, i.e. consumer builds probably won't pass due to all the rule changes.
- In our monorepo we've added a lot of rule opt-outs to `.eslintrc`. Should those be mirrored here? Or is it left up to consumers. Maybe we could put the opt-outs into the `.eslintrc` of `backpack-react-scripts`?