### PR TITLE
[NOJIRA] Upgraded eslint-config-airbnb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## UNRELEASED
+### Changed
+- Upgraded the following peer dependencies:
+  - babel-eslint: `^8.2.5` -> `^8.2.6`
+  - [eslint](https://github.com/eslint/eslint/blob/master/CHANGELOG.md): `^4.19.1` -> `^5.4.0`
+  - [eslint-config-airbnb](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/CHANGELOG.md): `^17.0.0` -> `^17.1.0`
+  - [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import/blob/master/CHANGELOG.md): `^2.13.0` -> `^2.14.0`
+  - [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md): `^6.1.0` -> `^6.1.1`
+  - [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md): `^7.10.0` -> `^7.11.1`
+  - [eslint-plugin-backpack](https://github.com/Skyscanner/eslint-plugin-backpack/blob/master/changelog.md): `^0.2.0` -> `^0.2.2`
+- Relaxed the rule for `jsx-a11y/label-has-associated-control` to only assert `either` as opposed to `both`.
+
 ## 4.0.0-beta.8 - Disabled `react/jsx-one-expression-per-line` 
 ### Changed
 - Disabled `react/jsx-one-expression-per-line`, temporarilly - https://github.com/airbnb/javascript/commit/b6a268f780177e03b573a4f0df95ecc0d2e8783e#diff-c0191b2bdd5bfebebb8cec31d0f3993c
@@ -26,9 +38,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - [eslint](https://github.com/eslint/eslint/blob/master/CHANGELOG.md): `^4.9.0` -> `^4.19.1`
   - [eslint-config-airbnb](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/CHANGELOG.md): `^16.1.0` -> `^17.0.0`
   - [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import/blob/master/CHANGELOG.md): `^2.8.0` -> `^2.10.0`
-  - [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md): -> `^6.0.2` -> `^6.1.0`
-  - [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md): -> `^7.4.0` -> `^7.10.0`
-  - [eslint-plugin-backpack](https://github.com/Skyscanner/eslint-plugin-backpack/blob/master/changelog.md): -> `^0.0.2` -> `^0.1.0`
+  - [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md): `^6.0.2` -> `^6.1.0`
+  - [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md): `^7.4.0` -> `^7.10.0`
+  - [eslint-plugin-backpack](https://github.com/Skyscanner/eslint-plugin-backpack/blob/master/changelog.md): `^0.0.2` -> `^0.1.0`
 
 ## 4.0.0-beta.3 - Auto-import Backpack tokens
 
@@ -53,11 +65,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md): `^6.10.0` -> `^7.4.0`
 
 ## 2.0.0 - Changed parser to `babel-eslint`
-## Changed
+### Changed
 - Changed parser to `babel-eslint` to support dynamic `import()` statements used with Webpack 2
 
 ## 1.1.0 - Add JSDoc validation
-### Changed
+### Added
 - Validate JSDoc (when present)
 
 ## 1.0.0 - Upgraded airbnb config to v14

--- a/index.js
+++ b/index.js
@@ -32,10 +32,10 @@ module.exports = {
     // See https://github.com/yannickcr/eslint-plugin-react/issues/1389
     'react/no-typos': 'off',
 
-     // One JSX Element Per Line
-     // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/jsx-one-expression-per-line.md	
-     // https://github.com/airbnb/javascript/commit/b6a268f780177e03b573a4f0df95ecc0d2e8783e#diff-c0191b2bdd5bfebebb8cec31d0f3993c     
-     // TODO: re-enable when an option for text children is available
+    // One JSX Element Per Line
+    // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/jsx-one-expression-per-line.md
+    // https://github.com/airbnb/javascript/commit/b6a268f780177e03b573a4f0df95ecc0d2e8783e#diff-c0191b2bdd5bfebebb8cec31d0f3993c
+    // TODO: re-enable when an option for text children is available
     'react/jsx-one-expression-per-line': 'off',
 
     // Added 'to' as a specialLink property, which prevents react-router's
@@ -49,5 +49,15 @@ module.exports = {
         aspects: ['noHref', 'invalidHref', 'preferButton'],
       },
     ],
+
+    // Modified from upstream eslint configuration to assert 'either' as opposed to 'both'.
+    // See https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/rules/react-a11y.js#L61.
+    'jsx-a11y/label-has-associated-control': ['error', {
+      labelComponents: [],
+      labelAttributes: [],
+      controlComponents: [],
+      assert: 'either',
+      depth: 25
+    }],
   },
 };

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "styleguide"
   ],
   "peerDependencies": {
-    "babel-eslint": "^8.2.5",
-    "eslint": "^4.19.1",
-    "eslint-config-airbnb": "^17.0.0",
-    "eslint-plugin-import": "^2.13.0",
-    "eslint-plugin-jsx-a11y": "^6.1.0",
-    "eslint-plugin-react": "^7.10.0",
-    "eslint-plugin-backpack": "^0.2.0"
+    "babel-eslint": "^8.2.6",
+    "eslint": "^5.4.0",
+    "eslint-config-airbnb": "^17.1.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jsx-a11y": "^6.1.1",
+    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-backpack": "^0.2.2"
   },
   "scripts": {
     "test": "(cd test && ./e2e-test.sh)"


### PR DESCRIPTION
Upgraded the following peer dependencies:

- babel-eslint: ^8.2.5 -> ^8.2.6
- eslint: ^4.19.1 -> ^5.4.0
- eslint-config-airbnb: ^17.0.0 -> ^17.1.0
- eslint-plugin-import: ^2.13.0 -> ^2.14.0
- eslint-plugin-jsx-a11y: ^6.1.0 -> ^6.1.1
- eslint-plugin-react: ^7.10.0 -> ^7.11.1
- eslint-plugin-backpack: ^0.2.0 -> ^0.2.2


I've tested this on the backpack codebase and there are no issues, apart from:
- Modified from upstream eslint configuration to assert 'either' as opposed to 'both'. See https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/rules/react-a11y.js#L61.
