### PR TITLE
[NOJIRA] Upgrade babel-eslint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.0.0-beta.10 - Upgraded `babel-eslint`
+
+### Changed
+- Upgraded the following peer dependencies:
+  - [babel-eslint](https://github.com/babel/babel-eslint/releases): `^8.2.6` -> `^10.0.0`
+  - [eslint](https://github.com/eslint/eslint/blob/master/CHANGELOG.md): `^5.4.0` -> `^5.6.0`
+
 ## 4.0.0-beta.9 - Upgraded `eslint-config-airbnb`
 ### Changed
 - Upgraded the following peer dependencies:

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "styleguide"
   ],
   "peerDependencies": {
-    "babel-eslint": "^8.2.6",
-    "eslint": "^5.4.0",
+    "babel-eslint": "^10.0.0",
+    "eslint": "^5.6.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",


### PR DESCRIPTION
Looking at the changelogs...

[babel-eslint](https://github.com/babel/babel-eslint/releases): 
- they now use babel 7 under the hood

[eslint](https://github.com/eslint/eslint/blob/master/CHANGELOG.md): 
- nothing major