### PR TITLE
Add "import/order" rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,5 +59,15 @@ module.exports = {
       assert: 'either',
       depth: 25
     }],
+
+    // Enforce a convention in the order of require/import statements
+    // See https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
+    'import/order': [
+      'error',
+      {
+        groups: ['builtin', 'external', 'parent', 'sibling', 'index'],
+        'newlines-between': 'always',
+      },
+    ],
   },
 };


### PR DESCRIPTION
Hi,

I think it makes sense to enforce some convention on the order of the imports and the new lines between them.

In my opinion, this helps a bit when reading the code, and also standardising a bit more the imports.