### PR TITLE
DINGO-1191: Integrate eslint-plugin-skyscanner-dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
 
-_Nothing yet..._
+### Changed
+- Integrate eslint-plugin-skyscanner-dates:
+  - eslint-plugin-skyscanner-dates: `^1.0.9`
 
 ## 5.0.0-beta.1 - Add import/order rule
 

--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@
 
 module.exports = {
   parser: 'babel-eslint',
-  extends: 'airbnb',
-  plugins: ['backpack'],
+  extends: ['airbnb', 'plugin:skyscanner-dates/warn'],
+  plugins: ['backpack', 'skyscanner-dates'],
   rules: {
     'valid-jsdoc': ['error'],
     'backpack/use-tokens': 'error',

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.12.3",
-    "eslint-plugin-backpack": "^0.2.2"
+    "eslint-plugin-backpack": "^0.2.2",
+    "eslint-plugin-skyscanner-dates": "^1.0.9"
   },
   "scripts": {
     "pretest": "npx ensure-node-env",


### PR DESCRIPTION
Integrate eslint-plugin-skyscanner-dates, setting the default to `warn`