### PR TITLE
Integrate "eslint-plugin-eslint-comments" plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
 
-_Nothing yet..._
+### Changed
+- Integrate `eslint-plugin-eslint-comments`, see [documentation](https://mysticatea.github.io/eslint-plugin-eslint-comments/) for more info.
 
 ## 5.0.0-beta.2 - Add skyscanner dates plugin
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
 
 module.exports = {
   parser: 'babel-eslint',
-  extends: ['airbnb', 'plugin:skyscanner-dates/warn'],
+  extends: ['airbnb', 'plugin:skyscanner-dates/warn', 'plugin:eslint-comments/recommended'],
   plugins: ['backpack', 'skyscanner-dates'],
   rules: {
     'valid-jsdoc': ['error'],
@@ -69,5 +69,14 @@ module.exports = {
         'newlines-between': 'always',
       },
     ],
+
+    // Additional ESLint rules for directive comments of ESLint
+    // See: https://github.com/mysticatea/eslint-plugin-eslint-comments
+    'eslint-comments/disable-enable-pair': ['warn', {allowWholeFile: true}],
+    'eslint-comments/no-aggregating-enable': 'warn',
+    'eslint-comments/no-duplicate-disable': 'warn',
+    'eslint-comments/no-unlimited-disable': 'warn',
+    'eslint-comments/no-unused-disable': 'warn',
+    'eslint-comments/no-unused-enable': 'warn',
   },
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.12.0",
     "eslint-config-airbnb": "^17.1.0",
+    "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.12.3",


### PR DESCRIPTION
When disabling some eslint rule, it's very easy to make mistakes like not enabling it again, forgetting to remove the disabled rule when the code is refactored...

This plugin checks those cases, allowing a safer way of disabling eslint rules.

I think it would be very useful to include it in our configuration.

I've set all of them to just warn (they error by default), as given those are not fixed automatically with `--fix` it might be hard for some repos to fix them all manually (although personally I would trigger an error and release the new version as major, but maybe this can be changed in a future release, once this one already has a good adoption).