### PR TITLE
Integrate "eslint-plugin-jest"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## UNRELEASED
 
 ### Changed
+- Integrate `eslint-plugin-jest`, see [documentation](https://github.com/jest-community/eslint-plugin-jest) for more into.
 - Integrate `eslint-plugin-eslint-comments`, see [documentation](https://mysticatea.github.io/eslint-plugin-eslint-comments/) for more info.
 
 ## 5.0.0-beta.2 - Add skyscanner dates plugin

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
 
 module.exports = {
   parser: 'babel-eslint',
-  extends: ['airbnb', 'plugin:skyscanner-dates/warn', 'plugin:eslint-comments/recommended'],
+  extends: ['airbnb', 'plugin:skyscanner-dates/warn', 'plugin:eslint-comments/recommended', "plugin:jest/recommended" ],
   plugins: ['backpack', 'skyscanner-dates'],
   rules: {
     'valid-jsdoc': ['error'],

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jest": "^22.17.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.12.3",
     "eslint-plugin-backpack": "^0.2.2",


### PR DESCRIPTION
This plugin should save us from accidentally committing focused tests. 

The default configuration also spots other issues with jest tests, like exactly the same names of tests inside a describe block etc. 

The full list of defaults can be found [here](https://github.com/jest-community/eslint-plugin-jest/blob/master/src/index.ts)