### PR TITLE
Add "jest-formatting" plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
 
+### Added
+
+- Integrate `eslint-plugin-jest-formatting`, see [documentation](https://github.com/dangreenisrael/eslint-plugin-jest-formatting) for more into.
+
 ## 5.0.0 - Added Prettier, new linting libraries and clean-up.
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -19,8 +19,9 @@ module.exports = {
     'prettier/react',
     'plugin:eslint-comments/recommended',
     'plugin:jest/recommended',
+    'plugin:jest-formatting/strict',
   ],
-  plugins: ['backpack', 'prettier'],
+  plugins: ['backpack', 'prettier', 'jest-formatting'],
   rules: {
     'prettier/prettier': 'error',
     'valid-jsdoc': ['error'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-skyscanner",
-  "version": "5.0.0-beta.3",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1092,6 +1092,11 @@
       "requires": {
         "@typescript-eslint/experimental-utils": "^1.13.0"
       }
+    },
+    "eslint-plugin-jest-formatting": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-formatting/-/eslint-plugin-jest-formatting-1.2.0.tgz",
+      "integrity": "sha512-EqsbDByAtdQa5vEhJFUFMqTW7fghN0Qhb8oulM7R3j9+9xRuMsQKCPjWvCIxpWhl3SJJmlxBC25o1pUXiBHaAw=="
     },
     "eslint-plugin-jsx-a11y": {
       "version": "6.2.3",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jest": "^22.21.0",
+    "eslint-plugin-jest-formatting": "^1.2.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.18.3",


### PR DESCRIPTION
I noticed the recently added `eslint-plugin-jest` has a section with related projects: https://github.com/jest-community/eslint-plugin-jest#related-projects

This section mentions `eslint-plugin-jest-formatting`: https://github.com/dangreenisrael/eslint-plugin-jest-formatting

This looks like something that aligns to Prettier, as it enforces adding new lines before/after `expect` (when set to `strict`), `beforeEach`/`it`/... (when set to `recommended`) making the code easier to read.

What do you think about adding this plugin?
