### PR TITLE
Allow alias for deprecated React component lifecycle methods

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -19,6 +19,7 @@ eslint-config-airbnb
 eslint-config-skyscanner
 eslint-plugin-jsx-a11y
 jsdoc
+lifecycle
 lts
 peerdependencies
 plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
 
+### Added
+
+- Allow alias for deprecated React component lifecycle methods (like `UNSAFE_componentWillReceiveProps`). See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html
+
 ## 5.2.0 - Added `eslint-plugin-jest-formatting` and dependency updates
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -89,5 +89,16 @@ module.exports = {
     'eslint-comments/no-unlimited-disable': 'warn',
     'eslint-comments/no-unused-disable': 'warn',
     'eslint-comments/no-unused-enable': 'warn',
+
+    // Allow alias for deprecated React component lifecycle methods
+    // https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html
+    camelcase: [
+      'error',
+      {
+        properties: 'never',
+        ignoreDestructuring: false,
+        allow: ['^UNSAFE_'],
+      },
+    ],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-skyscanner",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-skyscanner",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Skyscanner's ESLint config.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
React 16.3 introduced `UNSAFE_componentWillReceiveProps` as an alias for `componentWillReceiveProps`, as this will be removed in React 17 (see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html)

This PR changes the behaviour of `camelcase` to allow the prefix `UNSAFE_`.