### PR TITLE
Add React config info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Update eslint-config-airbnb to 18.1.0
   - Migration guide here [v5 to v6](./docs/migration-from-5-to-6.md)
-- Integrate `eslint-plugin-react-hooks`.
 - Remove `eslint-plugin-jest-dom`, as it can create issues if `@testing-library/jest-dom` is not used.
+
+### Added
+
+- Integrate `eslint-plugin-react-hooks`.
 
 ## 5.4.0 - Added `eslint-plugin-jest-dom`
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://travis-ci.org/Skyscanner/eslint-config-skyscanner.svg?branch=master)](https://travis-ci.org/Skyscanner/eslint-config-skyscanner)
 [![npm version](https://img.shields.io/npm/v/eslint-config-skyscanner.svg)](https://www.npmjs.com/package/eslint-config-skyscanner)
 
-
 This package includes the shareable ESLint configuration used by Skyscanner.
 
 ## Installation
@@ -13,6 +12,20 @@ npm install --save-dev eslint-config-skyscanner
 ```
 
 Add `"extends": "skyscanner"` to your `.eslintrc`.
+
+## React
+
+`eslint-config-skyscanner` will try to detect automatically the version of React installed.
+
+If your project doesn't use it or it is not installed in the same `package.json` as `eslint-config-skyscanner`, it must be manually set in `.eslintrc`:
+
+```
+"settings": {
+  "react": {
+    "version": "16.4"
+  }
+}
+```
 
 ## Changelog
 

--- a/docs/migration-from-5-to-6.md
+++ b/docs/migration-from-5-to-6.md
@@ -2,6 +2,20 @@
 
 The main motivation for this is adding rule-of-hooks for react. (https://www.npmjs.com/package/eslint-plugin-react-hooks)
 
+# React
+
+`eslint-config-skyscanner` will try to detect automatically the version of React installed.
+
+If your project doesn't use it or it is not installed in the same `package.json` as `eslint-config-skyscanner`, it must be manually set in `.eslintrc`:
+
+```
+"settings": {
+  "react": {
+    "version": "16.4"
+  }
+}
+```
+
 # Breaking rules that have been disabled
 
 - `react/jsx-props-no-spreading` https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md


### PR DESCRIPTION
`eslint-plugin-react` shows a warning when running eslint in a project without React:
`Warning: React version was set to "detect" in eslint-plugin-react settings, but the "react" package is not installed. Assuming latest React version for linting.`

Adding a version in `.eslintrc.json` silens it:
```
"settings": {
  "react": {
    "version": "16"
  }
}
```

It's worth highlighting this in the migration guide and the readme.