### PR TITLE
TypeScript array type linting

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,7 @@
 # UNRELEASED
 
 This project adheres to [Semantic Versioning](http://semver.org/).
+
+## Added
+
+- Add `@typescript-eslint/array-type` rule and specify `array-simple` for TypeScript files.

--- a/index.js
+++ b/index.js
@@ -142,7 +142,6 @@ module.exports = {
     'jest/no-large-snapshots': 'off',
   },
   overrides: [
-    // TS linting configuration is taken directly from react-scripts: https://github.com/facebook/create-react-app/blob/9d0369b1fe3260e620b08effcf85f1edefc5d1ea/packages/eslint-config-react-app/index.js#L31
     {
       files: ['**/*.ts?(x)'],
       parser: '@typescript-eslint/parser',
@@ -202,8 +201,6 @@ module.exports = {
         ],
         'no-useless-constructor': 'off',
         '@typescript-eslint/no-useless-constructor': 'warn',
-
-        // Linting configuration below this line is NOT taken from react-scripts
         '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
       },
     },

--- a/index.js
+++ b/index.js
@@ -202,6 +202,9 @@ module.exports = {
         ],
         'no-useless-constructor': 'off',
         '@typescript-eslint/no-useless-constructor': 'warn',
+
+        // Linting configuration below this line is NOT taken from react-scripts
+        '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
       },
     },
   ],


### PR DESCRIPTION
# Description 

'Tools over rules'.

`[1, 2, 3]` can be typed in TypeScript as `number[]` or `Array<number>`.

`[1, 'two', 3]` can be typed as `Array<number | string>` or `(number | string)[]` 

A linting rule already exists for providing consistency: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md

This PR choses `array-simple`.

> Use T[] or readonly T[] for simple types (i.e. types which are just primitive names or type references). Use Array<T> or ReadonlyArray<T> for all other types (union types, intersection types, object types, function types, etc).

`T[]` is preferred for simple types as it matches what the syntax used for `tsc` error messages. It is preferred to match `tsc` if there is no downside. It is felt that due to `tsc` always using `T[]` then for simple types that syntax is familiar and equally readable to `Array<T>`.

`Array<T>` is preferred for non-simple types as it is more readable in non-simple situations. Complex types are thought to be more readable leading with the Array keyword, which outweighs matching `tsc`.

As this is autofixable then any change in opinion can be reflected in an update without work being required by package consumers.