### PR TITLE
Upgrading lint-staged to latest

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run lint-staged

--- a/package.json
+++ b/package.json
@@ -25,18 +25,15 @@
   "scripts": {
     "format:packagejson": "format-package -w",
     "lint": "npm run lint:js",
+    "lint-staged": "lint-staged",
     "lint:js": "eslint . --ext js",
     "lint:js:fix": "eslint . --ext js --fix",
     "postinstall": "node ./main.js",
+    "prepare": "husky install",
     "spellcheck": "mdspell --report --en-gb --ignore-numbers --ignore-acronyms --no-suggestions",
     "spellcheck:ci": "npm run spellcheck -- '**/*.md' '!LICENSE.md' '!**/node_modules/**/*.md'",
     "pretest": "npx ensure-node-env",
     "test": "(cd test && ./e2e-test.sh)"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
   },
   "lint-staged": {
     "!(LICENSE)*.md": [


### PR DESCRIPTION
This PR upgrades lint-staged to the latest version and due to husky being on v7 upgraded it to use the correct format as husky was not actually runnng due to the new format from v6/v7