### PR TITLE
NO-JIRA: Add consistent-type-imports - prefer type imports

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,3 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Bump @typescript-eslint/eslint-plugin from 5.8.0 to 5.9.0
 - Bump @typescript-eslint/parser from 5.8.0 to 5.9.1
 - Bump prettier from 2.3.2 to 2.5.1
+
+**Added**
+
+- `consistent-type-imports` to prefer `type-imports`

--- a/index.js
+++ b/index.js
@@ -202,6 +202,12 @@ module.exports = {
         'no-useless-constructor': 'off',
         '@typescript-eslint/no-useless-constructor': 'warn',
         '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
+        '@typescript-eslint/consistent-type-imports': [
+          'error',
+          {
+            prefer: 'type-imports',
+          },
+        ],
       },
     },
   ],


### PR DESCRIPTION
This would mean we bump a minor version.

Enforces our internal style guide of using `type` before a type import.

```js
// do
import type { MyType } from './types' 

// do not
import { MyType } from './types
```
https://stackoverflow.com/questions/61412000/do-i-need-to-use-the-import-type-feature-of-typescript-3-8-if-all-of-my-import

Released a beta under `eslint-config-skyscanner@10.4.0-beta.0` and tested it in one of our TypeScript projects.