### PR TITLE
Update import order

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -12,6 +12,7 @@ beta.9
 beta.10
 beta.11
 config
+destructure
 destructuring
 devdependencies
 eslint

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,3 +5,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 **Breaking**
 
 - Published under the `@skyscanner/` scope. To upgrade, first uninstall `eslint-config-skyscanner`, then install `@skyscanner/eslint-config-skyscanner`.
+- Change import order rule (fixable using `--fix`).

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,4 +2,6 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-**Updated**
+**Breaking**
+
+- Published under the `@skyscanner/` scope. To upgrade, first uninstall `eslint-config-skyscanner`, then install `@skyscanner/eslint-config-skyscanner`.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,3 +6,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Published under the `@skyscanner/` scope. To upgrade, first uninstall `eslint-config-skyscanner`, then install `@skyscanner/eslint-config-skyscanner`.
 - Change import order rule (fixable using `--fix`).
+- Require object destructure key to be sorted (fixable using `--fix`).

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,5 +5,5 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 **Breaking**
 
 - Published under the `@skyscanner/` scope. To upgrade, first uninstall `eslint-config-skyscanner`, then install `@skyscanner/eslint-config-skyscanner`.
-- Change import order rule (fixable using `--fix`).
+- Change import groups order, and paths must be sorted alphabetically (fixable using `--fix`).
 - Require object destructure key to be sorted (fixable using `--fix`).

--- a/index.js
+++ b/index.js
@@ -23,7 +23,13 @@ module.exports = {
     'plugin:import/typescript',
     'plugin:typescript-enum/recommended',
   ],
-  plugins: ['backpack', 'prettier', 'jest-formatting', 'typescript-enum'],
+  plugins: [
+    'backpack',
+    'prettier',
+    'jest-formatting',
+    'sort-destructure-keys',
+    'typescript-enum',
+  ],
   rules: {
     'prettier/prettier': 'error',
     'valid-jsdoc': ['error'],
@@ -142,6 +148,10 @@ module.exports = {
         },
       },
     ],
+
+    // Require object destructure key to be sorted
+    // https://github.com/mthadley/eslint-plugin-sort-destructure-keys
+    'sort-destructure-keys/sort-destructure-keys': 'error',
 
     // Ensure consistent use of file extension within the import path
     // The airbnb config we extend does not support TypeScript so we override it here

--- a/index.js
+++ b/index.js
@@ -96,11 +96,50 @@ module.exports = {
 
     // Enforce a convention in the order of require/import statements
     // See https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
+    // Order:
+    //   1. builtin (node native)
+    //   2. react, react-dom, prop-types
+    //   3. external (other external libraries)
+    //   4. Backpack components
+    //   5. common package (shared functionailities between client and server)
+    //   6. parent (parent folders)
+    //   7. sibling (sibling folders)
+    //   8. index (same folder)
+    //   9. scss files
     'import/order': [
       'error',
       {
         groups: ['builtin', 'external', 'parent', 'sibling', 'index'],
         'newlines-between': 'always',
+        pathGroups: [
+          {
+            pattern: '{react,react-dom,prop-types}',
+            group: 'external',
+            position: 'before',
+          },
+          {
+            pattern:
+              '{bpk-*,bpk-**,bpk-*/**,bpk-*/**/**,@skyscanner/bpk-*/**/**}',
+            group: 'external',
+            position: 'after',
+          },
+          {
+            pattern: 'common/**',
+            group: 'external',
+            position: 'after',
+          },
+          {
+            pattern: '*.scss',
+            group: 'sibling',
+            patternOptions: { matchBase: true },
+            position: 'after',
+          },
+        ],
+        pathGroupsExcludedImportTypes: ['react', 'react-dom', 'prop-types'],
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: true,
+        },
       },
     ],
 

--- a/main.js
+++ b/main.js
@@ -18,8 +18,8 @@
  */
 
 /* eslint-disable no-console */
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 
 const colors = require('colors/safe');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4059,6 +4059,14 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
       "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA=="
     },
+    "eslint-plugin-sort-destructure-keys": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-1.4.0.tgz",
+      "integrity": "sha512-txU9l22mblz7YpyjJNYFy4wb5PVXiRMbc9lqFPPhvY4wKyBBYQvb31TIcduf7iRb4Bv01aiXcJiuCkOOrVY48Q==",
+      "requires": {
+        "natural-compare-lite": "^1.4.0"
+      }
+    },
     "eslint-plugin-typescript-enum": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-enum/-/eslint-plugin-typescript-enum-2.1.0.tgz",
@@ -7470,6 +7478,11 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+    },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha1-F7CVgZiJef3a/gIB6TG6kzyWy7Q="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config-skyscanner",
+  "name": "@skyscanner/eslint-config-skyscanner",
   "version": "10.4.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config-skyscanner",
+  "name": "@skyscanner/eslint-config-skyscanner",
   "version": "10.4.0",
   "description": "Skyscanner's ESLint config.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "eslint-plugin-prettier": "^3.4.1",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "eslint-plugin-sort-destructure-keys": "^1.4.0",
     "eslint-plugin-typescript-enum": "^2.1.0",
     "prettier": "^2.5.1"
   },

--- a/test/pass.jsx
+++ b/test/pass.jsx
@@ -1,5 +1,28 @@
-import React from 'react';
+/* eslint-disable no-unused-vars,import/no-unresolved,import/extensions */
+// import/order
+import fs from 'fs';
+
 import PropTypes from 'prop-types';
+import React from 'react';
+import ReactDom from 'react-dom';
+
+import ExternalLibrary from 'external-library';
+
+import { fontSizeSm } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
+import BpkButton from 'bpk-component-button';
+import ArrowUpIcon from 'bpk-component-icon/sm/long-arrow-up';
+
+import SomeCommonFunctionality from 'common/some-functionality';
+
+import Component2 from '../../Component2';
+import Component1 from '../Component1';
+import SubComponent from '../Component1/SubComponent';
+import OtherComponent from '../OtherComponent';
+
+import SiblingComponent from './SiblingComponent';
+
+import STYLES from './styles.scss';
+/* eslint-enable no-unused-vars,import/no-unresolved,import/extensions */
 
 const Banner = ({ children }) => <div role="banner">{children}</div>;
 

--- a/test/pass.jsx
+++ b/test/pass.jsx
@@ -84,4 +84,17 @@ class Foo extends React.Component {
   }
 }
 
-export { SpreadProps, MyComponent, Fragments, Foo };
+// sort-destructure-keys
+const SortDestructureKeys = ({ anotherProp, oneProp }) => (
+  <React.Fragment>
+    <div>{oneProp}</div>
+    <div>{anotherProp}</div>
+  </React.Fragment>
+);
+
+SortDestructureKeys.propTypes = {
+  oneProp: PropTypes.string.isRequired,
+  anotherProp: PropTypes.string.isRequired,
+};
+
+export { SpreadProps, MyComponent, Fragments, Foo, SortDestructureKeys };


### PR DESCRIPTION
* Publish as scoped package (`@skyscanner/eslint-config-skyscanner`)
* Update import groups (and paths must be sorted alphabetically). The new order is:
  1. builtin (node native)
  1. react, react-dom, prop-types
  1. external (other external libraries)
  1. Backpack components
  1. common package (shared functionailities between client and server)
  1. parent (parent folders)
  1. sibling (sibling folders)
  1. index (same folder)
  1. scss files
 * Require object destructure key to be sorted 