### PR TITLE
[NO-JIRA][import/order] Include react-dom/server to the list of top level imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ module.exports = {
         'newlines-between': 'always',
         pathGroups: [
           {
-            pattern: '{react,react-dom,prop-types}',
+            pattern: '{react,react-dom,react-dom/server,prop-types}',
             group: 'external',
             position: 'before',
           },


### PR DESCRIPTION
# Context

Seems like `import/order` doesn't pick up `require('react-dom/server')` as `react-dom`, and places it somewhere bellow React imports.

# Changes

**Before**: ([example](https://github.skyscannertools.net/adverts/content-lab/blob/master/app/routes/marketplace/viewContext.js#L8))

```js
const React = require('react');

const { getRumSetupHtml } = require('@skyscanner-internal/mshell-node-rum');
const {
  template: { createClientSideParams },
} = require('node-microsite-core');
const ReactDOMServer = require('react-dom/server');
```

**After**:

```js
const React = require('react');
const ReactDOMServer = require('react-dom/server');
// rest of the imports
const { getRumSetupHtml } = require('@skyscanner-internal/mshell-node-rum');
const {
  template: { createClientSideParams },
} = require('node-microsite-core');
```