### PR TITLE
Take into account css files in import groups order

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -12,6 +12,7 @@ beta.9
 beta.10
 beta.11
 config
+css
 destructure
 destructuring
 devdependencies

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,4 +4,5 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Updated
 
+- Take into account css files in import groups order (fixable using `--fix`).
 - Bump eslint-plugin-prettier from 3.4.1 to 4.0.0

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ module.exports = {
     //   7. sibling (sibling folders)
     //   8. index (same folder)
     //   9. Types
-    //  10. scss files
+    //  10. Style files (scss, css)
     'import/order': [
       'error',
       {
@@ -136,7 +136,7 @@ module.exports = {
             position: 'after',
           },
           {
-            pattern: '*.scss',
+            pattern: '{*.scss,*.css}',
             group: 'type',
             patternOptions: { matchBase: true },
             position: 'after',

--- a/test/pass.jsx
+++ b/test/pass.jsx
@@ -21,6 +21,7 @@ import OtherComponent from '../OtherComponent';
 
 import SiblingComponent from './SiblingComponent';
 
+import STYLES2 from './styles.css';
 import STYLES from './styles.scss';
 /* eslint-enable no-unused-vars,import/no-unresolved,import/extensions */
 


### PR DESCRIPTION
Take into account css files in import groups order (fixable using `--fix`). Treat the same as scss.