### PR TITLE
Remove alphabetise imports

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,3 +6,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Take into account css files in import groups order (fixable using `--fix`).
 - Bump eslint-plugin-prettier from 3.4.1 to 4.0.0
+- Do no enforce imports being sorted alphabetically.

--- a/index.js
+++ b/index.js
@@ -143,10 +143,6 @@ module.exports = {
           },
         ],
         pathGroupsExcludedImportTypes: ['react', 'react-dom', 'prop-types'],
-        alphabetize: {
-          order: 'asc',
-          caseInsensitive: true,
-        },
       },
     ],
 


### PR DESCRIPTION
Alphabetisation seems to be creating issues in some projects, so removing this rule.