### PR TITLE
Update "import/order" to take into account Backpack single package

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,7 @@
 # UNRELEASED
 
 This project adheres to [Semantic Versioning](http://semver.org/).
+
+## Updated
+
+- Take into account the new Backpack single package in import groups.

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ module.exports = {
           },
           {
             pattern:
-              '{bpk-*,bpk-**,bpk-*/**,bpk-*/**/**,@skyscanner/bpk-*/**/**}',
+              '{bpk-*,bpk-**,bpk-*/**,bpk-*/**/**,@skyscanner/bpk-*/**/**,@skyscanner/backpack-web/**/**}',
             group: 'external',
             position: 'after',
           },

--- a/test/pass.jsx
+++ b/test/pass.jsx
@@ -11,6 +11,7 @@ import ExternalLibrary from 'external-library';
 import { fontSizeSm } from '@skyscanner/bpk-foundations-web/tokens/base.es6';
 import BpkButton from 'bpk-component-button';
 import ArrowUpIcon from 'bpk-component-icon/sm/long-arrow-up';
+import BpkButtonLink from '@skyscanner/backpack-web/bpk-component-link';
 
 import SomeCommonFunctionality from 'common/some-functionality';
 


### PR DESCRIPTION
Backpack is moving from a package per component to a single package: `@skyscanner/backpack-web`
The `import/order` rule must be update to account for the new package.