### PR TITLE
NO-JIRA: Adjust eslintrc.template to reflect scoped package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package includes the shareable ESLint configuration used by Skyscanner.
 npm install --save-dev @skyscanner/eslint-config-skyscanner
 ```
 
-Add `"extends": "@skyscanner/skyscanner"` to your `.eslintrc`.
+Add `"extends": "@skyscanner/eslint-config-skyscanner"` to your `.eslintrc`.
 
 ## React
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,7 +2,6 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-# 12.2.0
+# 12.2.1
 
-- Prefer default arguments to default props in functional components
-- Take into account the new Backpack single package in import groups.
+- Update guides about how to extend config to consistently say 'add @skyscanner/eslint-config-skyscanner'

--- a/eslintrc.template
+++ b/eslintrc.template
@@ -1,6 +1,6 @@
 {
   "parser": "babel-eslint",
   "extends": [
-      "skyscanner"
+      "@skyscanner/skyscanner"
   ]
 }

--- a/eslintrc.template
+++ b/eslintrc.template
@@ -1,6 +1,6 @@
 {
   "parser": "babel-eslint",
   "extends": [
-      "@skyscanner/skyscanner"
+      "@skyscanner/eslint-config-skyscanner"
   ]
 }

--- a/main.js
+++ b/main.js
@@ -90,7 +90,7 @@ try {
 
   if (hasExistingEslintConfig) {
     console.log(
-      'Please add "extends": [\'@skyscanner/skyscanner\'] to your eslint config',
+      'Please add "extends": [\'@skyscanner/eslint-config-skyscanner\'] to your eslint config',
     );
   } else {
     fs.copyFileSync(


### PR DESCRIPTION
When we moved to a scoped package we remembered to update the [warning message for people who already have an eslintrc](https://github.com/Skyscanner/eslint-config-skyscanner/blob/main/main.js#L93) but forgot to update so that the autogenerated eslintrc for people setting up from zero uses the correct extends config.

This PR updates the template.