### PR TITLE
[SEARCHEXP-337] Allow import() type imports in .d.ts files

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,7 @@
 # UNRELEASED
 
 This project adheres to [Semantic Versioning](http://semver.org/).
+
+
+**Added:**
+- Allow `import()` syntax in `.d.ts` files.

--- a/index.js
+++ b/index.js
@@ -289,20 +289,18 @@ module.exports = {
           },
         ],
       },
-      overrides: [
-        {
-          files: ["*.d.ts"],
-          rules: {
-            '@typescript-eslint/consistent-type-imports': [
-              'error',
-              {
-                disallowTypeAnnotations: false,
-                prefer: 'type-imports',
-              },
-            ],
+    },
+    {
+      files: ["*.d.ts"],
+      rules: {
+        '@typescript-eslint/consistent-type-imports': [
+          'error',
+          {
+            disallowTypeAnnotations: false,
+            prefer: 'type-imports',
           },
-        },
-      ],
+        ],
+      },
     },
   ],
 };

--- a/index.js
+++ b/index.js
@@ -289,6 +289,20 @@ module.exports = {
           },
         ],
       },
+      overrides: [
+        {
+          files: ["*.d.ts"],
+          rules: {
+            '@typescript-eslint/consistent-type-imports': [
+              'error',
+              {
+                disallowTypeAnnotations: false,
+                prefer: 'type-imports',
+              },
+            ],
+          },
+        },
+      ],
     },
   ],
 };

--- a/index.js
+++ b/index.js
@@ -291,7 +291,7 @@ module.exports = {
       },
     },
     {
-      files: ["*.d.ts"],
+      files: ['*.d.ts'],
       rules: {
         '@typescript-eslint/consistent-type-imports': [
           'error',


### PR DESCRIPTION
https://gojira.skyscanner.net/browse/SEARCHEXP-337

Eslint rules disallowed `import()` syntax for importing types to ensure consistency. However, in "ambient" module declarations (`.d.ts` files that extend a global module like a third-party library) are the only possibility to import them. Therefore, the rule has been updated in `eslint-config-rules` file allowing any`.d.ts` files to use `import()` syntax.

Before, the type import configurations had to be manually turned off for each file (see image below).
Before             |  After
:-------------------------:|:-------------------------:
 <img width="500" alt="before" src="https://user-images.githubusercontent.com/56206694/191821235-cf0aa57c-569a-454f-b12f-a762c7a08657.png"> | <img width="451" alt="ready" src="https://user-images.githubusercontent.com/56206694/191821253-10432c87-248d-4588-91d3-6628512718e0.png">