### PR TITLE
Disable default import of react

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -12,9 +12,11 @@ beta.8
 beta.9
 beta.10
 beta.11
+codemod
 config
 css
 destructure
+destructured
 destructuring
 devdependencies
 eslint
@@ -30,6 +32,7 @@ peerdependencies
 plugin
 skyscanner
 stylesheets
+useState
 v14
 v4
 v4.x

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,12 @@
 # UNRELEASED
 
 This project adheres to [Semantic Versioning](http://semver.org/).
+
+## Standardised React Imports
+
+This ensures that the 'preferred style' is used for react imports:
+
+> Change all default React imports (i.e. import React from "react") to destructured named imports (ex. import { useState } from "react") which is the preferred style going into the future.
+
+There is a codemod here created by the react team to change this in your codebase:
+https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = {
     'plugin:react-hooks/recommended',
     'plugin:import/typescript',
     'plugin:typescript-enum/recommended',
+    'plugin:react/jsx-runtime',
   ],
   plugins: [
     'backpack',

--- a/index.js
+++ b/index.js
@@ -220,6 +220,24 @@ module.exports = {
           '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
       },
     ],
+
+    // This ensures that the 'preferred style' is used for react imports:
+    // "
+    //   Change all default React imports (i.e. import React from "react") to destructured
+    //   named imports (ex. import { useState } from "react") which is the preferred style
+    //   going into the future.
+    // "
+    // There is a codemod here created by the react team to change this in your codebase:
+    // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports
+    'no-restricted-imports': [
+      'error',
+      {
+        name: 'react',
+        importNames: ['default'],
+        message:
+          "Please import directly (e.g. import { useEffect } from 'react').",
+      },
+    ],
   },
   overrides: [
     {

--- a/test/bpk-token-fail.jsx
+++ b/test/bpk-token-fail.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 const Banner = ({ children }) => (

--- a/test/package.json
+++ b/test/package.json
@@ -14,7 +14,8 @@
     "test:fail-jsdoc": "echo 'Expecting failure' && eslint jsdoc-fail.js; if [ $? -eq 1 ]; then exit 0; fi",
     "test:fail-bpk": "echo 'Expecting failure' && eslint bpk-token-fail.jsx; if [ $? -eq 1 ]; then exit 0; fi",
     "test:fail-prettier": "echo 'Expecting failure' && eslint prettier-fail.jsx; if [ $? -eq 1 ]; then exit 0; fi",
-    "test": "npm run test:pass && npm run test:fail-jsdoc && npm run test:fail-bpk && npm run test:fail-prettier"
+    "test:fail-react": "echo 'Expecting failure' && eslint react-fail.tsx; if [ $? -eq 1 ]; then exit 0; fi",
+    "test": "npm run test:pass && npm run test:fail-jsdoc && npm run test:fail-bpk && npm run test:fail-prettier && npm run test:fail-react"
   },
   "dependencies": {
     "prop-types": "^15.5.10",

--- a/test/pass.jsx
+++ b/test/pass.jsx
@@ -3,7 +3,7 @@
 import fs from 'fs';
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Component, Fragment } from 'react';
 import ReactDom from 'react-dom';
 
 import ExternalLibrary from 'external-library';
@@ -46,7 +46,7 @@ DestructuringComponent.propTypes = {
 const SpreadProps = (props) => <div role="banner" {...props} />;
 
 // react/static-property-placement
-class MyComponent extends React.Component {
+class MyComponent extends Component {
   static propTypes = { message: PropTypes.string.isRequired };
 
   constructor(props: PropTypes) {
@@ -68,9 +68,9 @@ class MyComponent extends React.Component {
 
 // react/jsx-fragments
 const Fragments = (props) => (
-  <React.Fragment>
+  <Fragment>
     <Banner>{props.message}</Banner>
-  </React.Fragment>
+  </Fragment>
 );
 
 Fragments.propTypes = {
@@ -78,7 +78,7 @@ Fragments.propTypes = {
 };
 
 // react/state-in-constructor
-class Foo extends React.Component {
+class Foo extends Component {
   state = { bar: 'Bar' };
 
   render() {
@@ -97,10 +97,10 @@ FunctionalComponentWithOptionalProps.propTypes = {
 
 // sort-destructure-keys
 const SortDestructureKeys = ({ anotherProp, oneProp }) => (
-  <React.Fragment>
+  <Fragment>
     <div>{oneProp}</div>
     <div>{anotherProp}</div>
-  </React.Fragment>
+  </Fragment>
 );
 
 SortDestructureKeys.propTypes = {

--- a/test/prettier-fail.jsx
+++ b/test/prettier-fail.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 const Banner = ({ children }) => { return (<div role="banner">{children}</div>) };

--- a/test/react-fail.tsx
+++ b/test/react-fail.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export const CustomComponent = () => {
+  const [val, setVal] = React.useState('initial value');
+
+  React.useEffect(() => {
+    setVal('new value')
+  }, [setVal]);
+
+  return val;
+};
+
+export default CustomComponent;


### PR DESCRIPTION
It is now discouraged to import react as follows:

```js
import React from 'react';
```

This is because the team have shown their intention to remove the default export in the future.

In preparation for this the react team encourage the following (Dan Abramov from the react team):
![Screenshot 2022-11-28 at 09 49 28](https://user-images.githubusercontent.com/9036408/204246869-5e27264a-98cb-44b3-bcb4-60628e0a740f.png)

https://twitter.com/dan_abramov/status/1308739731551858689

There is also a codemod created by the react team to do this:
https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports


This change standardises on the first syntax above (this may need discussion about whether it is the prefferd style), and makes it such that the user will see an error if using a different style:
![Screenshot 2022-11-28 at 09 58 08](https://user-images.githubusercontent.com/9036408/204248799-478df8c4-23b1-4686-b854-2ca5528fc3fb.png)