### PR TITLE
[KOA-6221] Update eslint-plugin-backpack to v5 which supports ESLint 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased changes](./UNRELEASED.md)
 
+# 15.1.0
+
+- Bump eslint-plugin-backpack from 4.0.1 to 5.0.0 to support ESLint 8
+
 # 15.0.0
 
 ## Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,9 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
+This file remains for historical references, but all new releases are now documented in the package's [Releases page](https://github.com/Skyscanner/eslint-config-skyscanner/releases).
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
-
-[Unreleased changes](./UNRELEASED.md)
-
-# 15.1.0
-
-- Bump eslint-plugin-backpack from 4.0.1 to 5.0.0 to support ESLint 8
 
 # 15.0.0
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,0 @@
-# UNRELEASED
-
-This project adheres to [Semantic Versioning](http://semver.org/).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -4,13 +4,11 @@ This package can be published by members of the Koala team and authorised Skysca
 
 ### Stable release
 
-To do this:
+Stable releases are now automated.
 
-- Add a title with the new version for changes in the `CHANGELOG.md` and copy the changes to be published from the `UNRELEASED.md` file to the new section.
-- Stage those changes (`git add CHANGELOG.md UNRELEASED.md`).
-- Run `npm version -f major|minor|patch`. This will create a tagged commit changing the version in `package.json`, and the changes in `CHANGELOG.md`.
-- Run `npm publish --registry=https://registry.npmjs.org/`.
-- Run `git push && git push --tags`.
+After a pull request is merged an authorised member next publishes a release via the [GitHub Release UI](https://github.com/Skyscanner/eslint-config-skyscanner/releases).
+
+This will generate an email confirmation. Once this has been confirmed the tag and release will be generated.
 
 ### Alpha/Beta release
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint": "^8.45.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-backpack": "^4.0.1",
+        "eslint-plugin-backpack": "^5.0.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jest": "^26.0.0",
@@ -3317,12 +3317,12 @@
       }
     },
     "node_modules/eslint-plugin-backpack": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-backpack/-/eslint-plugin-backpack-4.0.1.tgz",
-      "integrity": "sha512-omOEjkRz9m0jx1XXvvXq0GK27rIMBZQ5FRIrqmeVuDQvsKxHLiGLhkhA+eSmBlcBdXKoqMqsn6aV+2f/I1tIGg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-backpack/-/eslint-plugin-backpack-5.0.0.tgz",
+      "integrity": "sha512-zvqXT9rHQUxjlcYU2iDTcan1ueH+++mVHU5zRVeZnB77eXNfEpUoEhvpFZul/odQmeMZPJQ5ft1vVYTfScZ1Iw==",
       "dependencies": {
         "bpk-tokens": "^36.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "tinycolor2": "^1.4.1"
       },
       "engines": {
@@ -11631,12 +11631,12 @@
       }
     },
     "eslint-plugin-backpack": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-backpack/-/eslint-plugin-backpack-4.0.1.tgz",
-      "integrity": "sha512-omOEjkRz9m0jx1XXvvXq0GK27rIMBZQ5FRIrqmeVuDQvsKxHLiGLhkhA+eSmBlcBdXKoqMqsn6aV+2f/I1tIGg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-backpack/-/eslint-plugin-backpack-5.0.0.tgz",
+      "integrity": "sha512-zvqXT9rHQUxjlcYU2iDTcan1ueH+++mVHU5zRVeZnB77eXNfEpUoEhvpFZul/odQmeMZPJQ5ft1vVYTfScZ1Iw==",
       "requires": {
         "bpk-tokens": "^36.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "tinycolor2": "^1.4.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint": "^8.45.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-backpack": "^4.0.1",
+    "eslint-plugin-backpack": "^5.0.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^26.0.0",


### PR DESCRIPTION
Brings in https://github.com/Skyscanner/eslint-plugin-backpack/blob/main/CHANGELOG.md#500, for missed ESLint 8 compatibility.

This will be a minor release.