### PR TITLE
[ARGG-857] Add rule forbidding the use of axios library

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ If your project doesn't use it or it is not installed in the same `package.json`
 }
 ```
 
+## Rules included in this repository
+
+Custom rules are currently wrapped in a locally-installed package.
+This will no longer be needed once the eslint version used accepts objects as shown in
+[custom rules tutorial](https://eslint.org/docs/latest/extend/custom-rule-tutorial#step-8-use-the-plugin-locally).
+
 ## Changelog
 
 [View our up-to-date changelog](./CHANGELOG.md).

--- a/eslint-plugin-skyscanner-no-axios/package.json
+++ b/eslint-plugin-skyscanner-no-axios/package.json
@@ -1,9 +1,3 @@
 {
-  "name": "eslint-plugin-skyscanner-no-axios",
-  "version": "0.0.1",
-  "description": "Eslint plugin forbidding direct use of axios",
-  "main": "src/index.js",
-  "peerDependencies": {
-    "eslint": ">=8.0.0"
-  }
+  "main": "src/index.js"
 }

--- a/eslint-plugin-skyscanner-no-axios/package.json
+++ b/eslint-plugin-skyscanner-no-axios/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "eslint-plugin-skyscanner-no-axios",
+  "version": "0.0.1",
+  "description": "Eslint plugin forbidding direct use of axios",
+  "main": "src/index.js",
+  "peerDependencies": {
+    "eslint": ">=8.0.0"
+  }
+}

--- a/eslint-plugin-skyscanner-no-axios/package.json
+++ b/eslint-plugin-skyscanner-no-axios/package.json
@@ -1,3 +1,6 @@
 {
-  "main": "src/index.js"
+  "main": "src/index.js",
+  "peerDependencies": {
+    "eslint": ">=8.53.0"
+  }
 }

--- a/eslint-plugin-skyscanner-no-axios/package.json
+++ b/eslint-plugin-skyscanner-no-axios/package.json
@@ -1,6 +1,6 @@
 {
   "main": "src/index.js",
   "peerDependencies": {
-    "eslint": ">=8.53.0"
+    "eslint": "^8.53.0"
   }
 }

--- a/eslint-plugin-skyscanner-no-axios/src/index.js
+++ b/eslint-plugin-skyscanner-no-axios/src/index.js
@@ -1,14 +1,6 @@
 const noAxios = require('./rules/no-axios');
 
 module.exports = {
-  configs: {
-    error: {
-      plugins: ['skyscanner-no-axios'],
-      rules: {
-        'skyscanner-no-axios/no-axios': 'error',
-      },
-    },
-  },
   rules: {
     'no-axios': noAxios,
   },

--- a/eslint-plugin-skyscanner-no-axios/src/index.js
+++ b/eslint-plugin-skyscanner-no-axios/src/index.js
@@ -1,0 +1,15 @@
+const noAxios = require('./rules/no-axios');
+
+module.exports = {
+  configs: {
+    error: {
+      plugins: ['skyscanner-no-axios'],
+      rules: {
+        'skyscanner-no-axios/no-axios': 'error',
+      },
+    },
+  },
+  rules: {
+    'no-axios': noAxios,
+  },
+};

--- a/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.js
+++ b/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.js
@@ -19,6 +19,14 @@ module.exports = {
         context.report(node, 'Deprecated import of axios package');
       }
     },
+    ImportExpression: (node) => {
+      if (
+        node.source.value === 'axios' ||
+        node.source.value.indexOf('axios/') === 0
+      ) {
+        context.report(node, 'Deprecated import of axios package');
+      }
+    },
   }),
   meta: {
     docs: {

--- a/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.js
+++ b/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.js
@@ -1,0 +1,30 @@
+module.exports = {
+  create: (context) => ({
+    CallExpression: (node) => {
+      if (
+        node.callee.name === 'require' &&
+        node.arguments.length > 0 &&
+        typeof node.arguments[0].value === 'string' &&
+        (node.arguments[0].value === 'axios' ||
+          node.arguments[0].value.indexOf('axios/') === 0)
+      ) {
+        context.report(node, 'Deprecated require of axios package');
+      }
+    },
+    ImportDeclaration: (node) => {
+      if (
+        node.source.value === 'axios' ||
+        node.source.value.indexOf('axios/') === 0
+      ) {
+        context.report(node, 'Deprecated import of axios package');
+      }
+    },
+  }),
+  meta: {
+    docs: {
+      description:
+        'Deprecate the use of axios due to potential sensitive information leaks',
+    },
+    type: 'problem',
+  },
+};

--- a/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.test.js
+++ b/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.test.js
@@ -4,7 +4,7 @@ const noAxios = require('./no-axios');
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 'latest',
     sourceType: 'module',
   },
 });
@@ -69,6 +69,24 @@ ruleTester.run('no-axios', noAxios, {
     },
     {
       code: 'import { foo } from "axios";',
+      errors: [
+        {
+          message: 'Deprecated import of axios package',
+        },
+      ],
+    },
+
+    {
+      code: 'import("axios").then(() => console.log("foo"));',
+      errors: [
+        {
+          message: 'Deprecated import of axios package',
+        },
+      ],
+    },
+
+    {
+      code: 'const axios = await import("axios");',
       errors: [
         {
           message: 'Deprecated import of axios package',

--- a/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.test.js
+++ b/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.test.js
@@ -9,7 +9,7 @@ const ruleTester = new RuleTester({
   },
 });
 
-ruleTester.run('no-moment', noAxios, {
+ruleTester.run('no-axios', noAxios, {
   valid: [
     {
       code: 'const test = require("foo-axios");',

--- a/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.test.js
+++ b/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.test.js
@@ -51,5 +51,29 @@ ruleTester.run('no-axios', noAxios, {
         },
       ],
     },
+    {
+      code: 'const { foo } = require("axios");',
+      errors: [
+        {
+          message: 'Deprecated require of axios package',
+        },
+      ],
+    },
+    {
+      code: 'const foo = require("axios/some/internal/thing").default;',
+      errors: [
+        {
+          message: 'Deprecated require of axios package',
+        },
+      ],
+    },
+    {
+      code: 'import { foo } from "axios";',
+      errors: [
+        {
+          message: 'Deprecated import of axios package',
+        },
+      ],
+    },
   ],
 });

--- a/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.test.js
+++ b/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.test.js
@@ -60,7 +60,7 @@ ruleTester.run('no-axios', noAxios, {
       ],
     },
     {
-      code: 'const foo = require("axios/some/internal/thing").default;',
+      code: 'const foo = require("axios").default;',
       errors: [
         {
           message: 'Deprecated require of axios package',

--- a/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.test.js
+++ b/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.test.js
@@ -1,0 +1,55 @@
+const { RuleTester } = require('eslint');
+
+const noAxios = require('./no-axios');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-moment', noAxios, {
+  valid: [
+    {
+      code: 'const test = require("foo-axios");',
+    },
+    {
+      code: 'import test from "foo-axios";',
+    },
+  ],
+  invalid: [
+    {
+      code: 'const axios = require("axios");',
+      errors: [
+        {
+          message: 'Deprecated require of axios package',
+        },
+      ],
+    },
+    {
+      code: 'import axios from "axios";',
+      errors: [
+        {
+          message: 'Deprecated import of axios package',
+        },
+      ],
+    },
+    {
+      code: 'const foo = require("axios/some/internal/thing");',
+      errors: [
+        {
+          message: 'Deprecated require of axios package',
+        },
+      ],
+    },
+    {
+      code: 'import foo from "axios/some/internal/thing";',
+      errors: [
+        {
+          message: 'Deprecated import of axios package',
+        },
+      ],
+    },
+  ],
+});

--- a/index.js
+++ b/index.js
@@ -39,12 +39,14 @@ module.exports = {
     'jest-formatting',
     'sort-destructure-keys',
     'typescript-enum',
+    'skyscanner-no-axios',
   ],
   rules: {
     'prettier/prettier': 'error',
     'valid-jsdoc': ['error'],
     'backpack/use-tokens': 'error',
     'backpack/use-components': 'off',
+    'skyscanner-no-axios/no-axios': 'error',
 
     // This rule is pretty restrictive and we feel this decision should be left to developers to decide on a case by case basis.
     // A file can contain more than one class and still have a single responsibility

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyscanner/eslint-config-skyscanner",
-  "version": "15.0.0",
+  "version": "16.100.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyscanner/eslint-config-skyscanner",
-      "version": "15.0.0",
+      "version": "16.100.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -28,6 +28,7 @@
         "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-skyscanner-no-axios": "file:./eslint-plugin-skyscanner-no-axios",
         "eslint-plugin-sort-destructure-keys": "^1.5.0",
         "eslint-plugin-typescript-enum": "^2.1.0",
         "prettier": "^3.0.3"
@@ -44,6 +45,19 @@
       "engines": {
         "node": ">=16.13.0",
         "npm": ">=8.1.0"
+      }
+    },
+    "eslint-plugin-no-axios": {
+      "version": "0.0.1",
+      "extraneous": true,
+      "peerDependencies": {
+        "eslint": ">=8.0.0"
+      }
+    },
+    "eslint-plugin-skyscanner-no-axios": {
+      "version": "0.0.1",
+      "peerDependencies": {
+        "eslint": ">=8.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4042,6 +4056,10 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/eslint-plugin-skyscanner-no-axios": {
+      "resolved": "eslint-plugin-skyscanner-no-axios",
+      "link": true
     },
     "node_modules/eslint-plugin-sort-destructure-keys": {
       "version": "1.5.0",
@@ -12938,6 +12956,10 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "requires": {}
+    },
+    "eslint-plugin-skyscanner-no-axios": {
+      "version": "file:eslint-plugin-skyscanner-no-axios",
       "requires": {}
     },
     "eslint-plugin-sort-destructure-keys": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyscanner/eslint-config-skyscanner",
-  "version": "15.0.0",
+  "version": "16.100.0",
   "description": "Skyscanner's ESLint config.",
   "license": "Apache-2.0",
   "engines": {
@@ -58,6 +58,7 @@
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-jest": "^27.6.0",
     "eslint-plugin-jest-formatting": "^3.1.0",
+    "eslint-plugin-skyscanner-no-axios": "file:./eslint-plugin-skyscanner-no-axios",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-react": "^7.33.2",

--- a/test/no-axios-fail.jsx
+++ b/test/no-axios-fail.jsx
@@ -1,0 +1,5 @@
+/* eslint-disable no-unused-vars,import/no-unresolved,import/extensions */
+// import/order
+import axios from 'axios';
+
+/* eslint-enable no-unused-vars,import/no-unresolved,import/extensions */

--- a/test/no-axios-fail.jsx
+++ b/test/no-axios-fail.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars,import/no-unresolved,import/extensions */
-// import/order
+// skyscanner-no-axios/no-axios
 import axios from 'axios';
 
 /* eslint-enable no-unused-vars,import/no-unresolved,import/extensions */

--- a/test/package.json
+++ b/test/package.json
@@ -16,7 +16,8 @@
     "test:fail-prettier": "echo 'Expecting failure' && eslint prettier-fail.jsx; if [ $? -eq 1 ]; then exit 0; fi",
     "test:fail-react": "echo 'Expecting failure' && eslint react-fail.tsx; if [ $? -eq 1 ]; then exit 0; fi",
     "test:fail-import-order": "echo 'Expecting failure' && eslint order-fail.jsx; if [ $? -eq 1 ]; then exit 0; fi",
-    "test": "npm run test:pass && npm run test:fail-jsdoc && npm run test:fail-bpk && npm run test:fail-prettier && npm run test:fail-react && npm run test:fail-import-order"
+    "test:skyscanner-no-axios": "cd ../eslint-plugin-skyscanner-no-axios; jest",
+    "test": "npm run test:skyscanner-no-axios && npm run test:pass && npm run test:fail-jsdoc && npm run test:fail-bpk && npm run test:fail-prettier && npm run test:fail-react && npm run test:fail-import-order"
   },
   "dependencies": {
     "prop-types": "^15.5.10",

--- a/test/package.json
+++ b/test/package.json
@@ -16,8 +16,9 @@
     "test:fail-prettier": "echo 'Expecting failure' && eslint prettier-fail.jsx; if [ $? -eq 1 ]; then exit 0; fi",
     "test:fail-react": "echo 'Expecting failure' && eslint react-fail.tsx; if [ $? -eq 1 ]; then exit 0; fi",
     "test:fail-import-order": "echo 'Expecting failure' && eslint order-fail.jsx; if [ $? -eq 1 ]; then exit 0; fi",
+    "test:fail-no-axios": "echo 'Expecting failure' && eslint no-axios-fail.jsx; if [ $? -eq 1 ]; then exit 0; fi",
     "test:skyscanner-no-axios": "cd ../eslint-plugin-skyscanner-no-axios; jest",
-    "test": "npm run test:skyscanner-no-axios && npm run test:pass && npm run test:fail-jsdoc && npm run test:fail-bpk && npm run test:fail-prettier && npm run test:fail-react && npm run test:fail-import-order"
+    "test": "npm run test:skyscanner-no-axios && npm run test:fail-no-axios && npm run test:pass && npm run test:fail-jsdoc && npm run test:fail-bpk && npm run test:fail-prettier && npm run test:fail-react && npm run test:fail-import-order"
   },
   "dependencies": {
     "prop-types": "^15.5.10",


### PR DESCRIPTION
What:
Adds a rule forbidding the use of axios library. The rule name is `skyscanner-no-axios/no-axios`

Why:
Axios is known to leak sensitive details in it's error objects

How:
- Created a minimal eslint plugin package in a subfolder of the repo
- Added a local install of that to the main package.json
- Added the necessary config/