### PR TITLE
Test if dynamic import argument is a string

### DIFF
--- a/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.js
+++ b/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.js
@@ -21,8 +21,9 @@ module.exports = {
     },
     ImportExpression: (node) => {
       if (
-        node.source.value === 'axios' ||
-        node.source.value.indexOf('axios/') === 0
+        typeof node.source.value === 'string' &&
+        (node.source.value === 'axios' ||
+          node.source.value.indexOf('axios/') === 0)
       ) {
         context.report(node, 'Deprecated import of axios package');
       }

--- a/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.test.js
+++ b/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.test.js
@@ -17,6 +17,11 @@ ruleTester.run('no-axios', noAxios, {
     {
       code: 'import test from "foo-axios";',
     },
+    {
+      // we can only detect actual strings,
+      // not string templates and other things that evaluate to string
+      code: 'const axios = await import(`axios`);',
+    },
   ],
   invalid: [
     {
@@ -87,6 +92,15 @@ ruleTester.run('no-axios', noAxios, {
 
     {
       code: 'const axios = await import("axios");',
+      errors: [
+        {
+          message: 'Deprecated import of axios package',
+        },
+      ],
+    },
+
+    {
+      code: 'import("axios").then(() => console.log("foo"));',
       errors: [
         {
           message: 'Deprecated import of axios package',


### PR DESCRIPTION
What:
Test if dynamic import argument is a string before testing if it's axios

Why:
It was breaking cases where the argument was an expression evaluating to string.