### PR TITLE
Remove no-axios rule peer dependency on eslint

### DIFF
--- a/eslint-plugin-skyscanner-no-axios/package.json
+++ b/eslint-plugin-skyscanner-no-axios/package.json
@@ -1,6 +1,3 @@
 {
-  "main": "src/index.js",
-  "peerDependencies": {
-    "eslint": "^8.53.0"
-  }
+  "main": "src/index.js"
 }

--- a/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.test.js
+++ b/eslint-plugin-skyscanner-no-axios/src/rules/no-axios.test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 const { RuleTester } = require('eslint');
 
 const noAxios = require('./no-axios');


### PR DESCRIPTION
What:
Removes eslint from no-axios rule's peer dependencies

Why:
It's not really necessary as the parent package depends on eslint anyway, and might be causing issues with dependabot.