### PR TITLE
[LOOM-1339]: bump @skyscanner/eslint-plugin-rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/core": "^7.23.7",
         "@babel/eslint-parser": "^7.23.3",
         "@babel/preset-react": "^7.23.3",
-        "@skyscanner/eslint-plugin-rules": "^1.0.1",
+        "@skyscanner/eslint-plugin-rules": "^1.1.1",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.1.0",
         "colors": "^1.4.0",
@@ -1673,9 +1673,9 @@
       }
     },
     "node_modules/@skyscanner/eslint-plugin-rules": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@skyscanner/eslint-plugin-rules/-/eslint-plugin-rules-1.0.1.tgz",
-      "integrity": "sha512-vkQMNn6Fhbn1Lhh4d0Nq8fOIK4SUqgIxFYnScijqtrYHwUoTD3uQq4VhoiOzoQMMzjHvvutODHSZDRkMGXTVNQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@skyscanner/eslint-plugin-rules/-/eslint-plugin-rules-1.1.1.tgz",
+      "integrity": "sha512-6NR2sm4P5zx0yOq2vbuMME3YLJGRwYJQDZAm+0z6XZ6vVUwU7Ht9i10QR6DMkW9a9awi9+gcrw0LuDC572Jruw=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@babel/core": "^7.23.7",
     "@babel/eslint-parser": "^7.23.3",
     "@babel/preset-react": "^7.23.3",
-    "@skyscanner/eslint-plugin-rules": "^1.0.1",
+    "@skyscanner/eslint-plugin-rules": "^1.1.1",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.1.0",
     "colors": "^1.4.0",


### PR DESCRIPTION
Bump @skyscanner/eslint-plugin-rules to allow access to the rule: `@skyscanner/rules/forbid-component-props`.