### PR TITLE
[NOJIRA]: update engine & npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,8 @@
         "markdown-spellcheck": "^1.3.1"
       },
       "engines": {
-        "node": ">=16.13.0",
-        "npm": ">=8.1.0"
+        "node": ">=18.18.0",
+        "npm": ">=9.8.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Skyscanner's ESLint config.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16.13.0",
-    "npm": ">=8.1.0"
+    "node": ">=18.18.0",
+    "npm": ">=9.8.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
After this merge: https://github.com/Skyscanner/eslint-config-skyscanner/pull/703 we need to align our own `engine` field with what is the expected node version (and npm version)