### PR TITLE
Bump eslint-plugin-rules to v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/core": "^7.23.7",
         "@babel/eslint-parser": "^7.24.1",
         "@babel/preset-react": "^7.24.1",
-        "@skyscanner/eslint-plugin-rules": "^1.1.1",
+        "@skyscanner/eslint-plugin-rules": "^1.2.0",
         "@typescript-eslint/eslint-plugin": "^7.12.0",
         "@typescript-eslint/parser": "^7.12.0",
         "colors": "^1.4.0",
@@ -1673,9 +1673,9 @@
       }
     },
     "node_modules/@skyscanner/eslint-plugin-rules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@skyscanner/eslint-plugin-rules/-/eslint-plugin-rules-1.1.1.tgz",
-      "integrity": "sha512-6NR2sm4P5zx0yOq2vbuMME3YLJGRwYJQDZAm+0z6XZ6vVUwU7Ht9i10QR6DMkW9a9awi9+gcrw0LuDC572Jruw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@skyscanner/eslint-plugin-rules/-/eslint-plugin-rules-1.2.0.tgz",
+      "integrity": "sha512-ALC0rHBUQFWDR8cxQSqvMfVRvnfvZA2oJTlxuFtgNO3qPxx1L17i9Nt2EbanqDe2/zhPQQV649BQwBFVFKEfzQ=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@babel/core": "^7.23.7",
     "@babel/eslint-parser": "^7.24.1",
     "@babel/preset-react": "^7.24.1",
-    "@skyscanner/eslint-plugin-rules": "^1.1.1",
+    "@skyscanner/eslint-plugin-rules": "^1.2.0",
     "@typescript-eslint/eslint-plugin": "^7.12.0",
     "@typescript-eslint/parser": "^7.12.0",
     "colors": "^1.4.0",


### PR DESCRIPTION
Bump eslint-plugin-rules to v1.2.0
https://github.com/Skyscanner/eslint-plugin-rules/releases/tag/1.2.0