### PR TITLE
Bump eslint-plugin-rules to v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/core": "^7.23.7",
         "@babel/eslint-parser": "^7.24.1",
         "@babel/preset-react": "^7.24.1",
-        "@skyscanner/eslint-plugin-rules": "^1.2.0",
+        "@skyscanner/eslint-plugin-rules": "^1.3.0",
         "@typescript-eslint/eslint-plugin": "^7.12.0",
         "@typescript-eslint/parser": "^7.12.0",
         "colors": "^1.4.0",
@@ -1673,9 +1673,9 @@
       }
     },
     "node_modules/@skyscanner/eslint-plugin-rules": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@skyscanner/eslint-plugin-rules/-/eslint-plugin-rules-1.2.0.tgz",
-      "integrity": "sha512-ALC0rHBUQFWDR8cxQSqvMfVRvnfvZA2oJTlxuFtgNO3qPxx1L17i9Nt2EbanqDe2/zhPQQV649BQwBFVFKEfzQ=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@skyscanner/eslint-plugin-rules/-/eslint-plugin-rules-1.3.0.tgz",
+      "integrity": "sha512-0mXSZW84duUfQZtfQKUsSRI2qsJizEFkl0cML0LbZmuUI1s1SHvIGqw0++BhXOTHJszCArZ0iDIyZ3NH/PWJCg=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@babel/core": "^7.23.7",
     "@babel/eslint-parser": "^7.24.1",
     "@babel/preset-react": "^7.24.1",
-    "@skyscanner/eslint-plugin-rules": "^1.2.0",
+    "@skyscanner/eslint-plugin-rules": "^1.3.0",
     "@typescript-eslint/eslint-plugin": "^7.12.0",
     "@typescript-eslint/parser": "^7.12.0",
     "colors": "^1.4.0",


### PR DESCRIPTION
Bump eslint-plugin-rules to v1.3.0
https://github.com/Skyscanner/eslint-plugin-rules/releases/tag/1.3.0