### PR TITLE
docs: add missing documentation and AI agent files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## What?
+
+_Briefly summarise the changes you have made._
+
+## Why?
+
+_Describe the reason why you have made the changes._
+
+## Changes:
+
+- _List a short summary of each change._
+
+## Testing:
+
+_Describe how you have tested the changes._
+
+## References:
+
+_Link to any extra context which may be useful to a reviewer. Should include:_
+
+- _Ticket number (if exists). E.g._ MLL-1234
+- _Any useful documentation._
+- _Related slack threads._

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+## Pull request descriptions
+
+When creating a pull request:
+- Always use the PR template from `.github/pull_request_template.md`.
+- Include relevant context from the `docs/plans/` plan file (not `*-implementation.md`) in the PR description body. This preserves the reasoning and design decisions in git history via merge commit descriptions.
+- Do NOT include the plan file itself in the commit — plan files are gitignored as temporary artifacts.
+
+## Superpowers label
+
+When creating PRs, if the 'superpowers' skills were used, add a PR label `ai: sdd-superpowers` (creating the label if it doesn't exist).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](./AGENTS.md) for agent instructions.


### PR DESCRIPTION
## What?

Add missing standardised documentation and AI agent instruction files to meet Production Standards.

## Why?

Production Standards require all repositories to have:
- **Documentation files**: `README.md`, `CONTRIBUTING.md`, `pull_request_template.md`
- **AI agent files**: `AGENTS.md`, `CLAUDE.md`

These files reduce barriers for new contributors, accelerate onboarding, and ensure AI coding agents have the structured context they need to work effectively.

## Changes:

- Added missing documentation files where absent
- Added `AGENTS.md` — agent-agnostic instructions based on the corresponding cookiecutter template
- Added `CLAUDE.md` — references `AGENTS.md` so Claude Code picks up the shared instructions

## Testing:

- No runtime changes. These are documentation and instruction files only.

## References:

- MLL-1822
- [Production Standards — AI Readiness](https://production-standards.skyscannerpage.com/standards/inner-source/ai-readiness/)
- [Production Standards — Documentation](https://production-standards.skyscannerpage.com/standards/inner-source/documentation/)